### PR TITLE
fallback is wrong

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,35 @@ var vendor = proto.matchesSelector
  * Expose `match()`.
  */
 
-module.exports = match;
+module.exports = vendor 
+  ? match
+  // Fallback for IE8 etc..
+  : function match (el, selector) {
+    var root = el
+      , frag
+
+    while (root.parentNode) {
+      root = root.parentNode;
+    }
+
+    // root can't be the el unless its either a Document or a DocumentFragment
+    if (root === el && !(root instanceof Document || root instanceof DocumentFragment)) {
+      root = frag = document.createDocumentFragment();
+      frag.appendChild(el);
+    }
+
+    var nodes = root.querySelectorAll(selector)
+      , i = nodes.length
+    while (i--) {
+      if (nodes[i] === el) {
+        // detach from DocumentFragment if we used one
+        if (frag) frag.removeChild(frag.lastChild)
+        return true
+      }
+    }
+
+    return false
+  } 
 
 /**
  * Match `el` to `selector`.
@@ -31,10 +59,5 @@ module.exports = match;
  */
 
 function match(el, selector) {
-  if (vendor) return vendor.call(el, selector);
-  var nodes = el.parentNode.querySelectorAll(selector);
-  for (var i = 0; i < nodes.length; ++i) {
-    if (nodes[i] == el) return true;
-  }
-  return false;
+  return vendor.call(el, selector);
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -6,7 +6,7 @@ function assert(expr) {
   if (!expr) throw new Error('assertion failed');
 }
 
-var ul = domify('<ul><li><em>foo</em></li></ul>');
+var ul = domify('<ul><li><em>foo</em></li></ul>')[0];
 var li = ul.children[0];
 var em = li.children[0];
 
@@ -22,8 +22,8 @@ describe('matchesSelector(el, selector)', function(){
     assert(true === matches(li, 'li'));
     assert(false === matches(li, 'div > li'));
 
-    assert(true == matches(ul, 'ul'));
-    assert(true == matches(ul, 'div ul'));
-    assert(false == matches(ul, 'body > ul'));
+    assert(true === matches(ul, 'ul'));
+    assert(false === matches(ul, 'div ul'));
+    assert(false === matches(ul, 'body > ul'));
   })
 })


### PR DESCRIPTION
as it was 

``` jade
div#a
  div#b
```

``` js
matches(b, '#a > #b')
```

would return false in ie8 and true in a modern browser since it only searched from the parentElement of `el`. This PR is probably still buggy; I honestly couldn't care less about IE8 for my own projects atm so didn't bother testing it. So take this PR as an issue which happens to be written in JS rather than something you can simply merge
