### PR TITLE
Add "browser" key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "git://github.com/component/matches-selector.git"
   },
+  "browser": {
+    "query": "component-query"
+  },
   "dependencies": {
     "component-query": "^0.0.3"
   },


### PR DESCRIPTION
Fixes npm + browserify compatibility.
