### PR TITLE
Fall back to `require('component-query')`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,11 @@
  * Module dependencies.
  */
 
-var query = require('query');
+try {
+  var query = require('query');
+} catch (err) {
+  var query = require('component-query');
+}
 
 /**
  * Element prototype.


### PR DESCRIPTION
This way, `component-matches-selector` won't break node code/tests when imported.